### PR TITLE
add descriptions from readme to tap

### DIFF
--- a/target_salesforce/target.py
+++ b/target_salesforce/target.py
@@ -13,18 +13,52 @@ class TargetSalesforce(Target):
 
     name = "target-salesforce"
     config_jsonschema = th.PropertiesList(
-        th.Property("client_id", th.StringType),
-        th.Property("client_secret", th.StringType, secret=True),
-        th.Property("refresh_token", th.StringType, secret=True),
-        th.Property("username", th.StringType),
-        th.Property("password", th.StringType, secret=True),
-        th.Property("security_token", th.StringType, secret=True),
-        th.Property("is_sandbox", th.BooleanType, default=False),
+        th.Property(
+            "client_id",
+            th.StringType,
+            description="OAuth client_id"
+        ),
+        th.Property(
+            "client_secret",
+            th.StringType,
+            secret=True,
+            description="OAuth client_secret"
+        ),
+        th.Property(
+            "refresh_token",
+            th.StringType,
+            secret=True,
+            description="OAuth refresh_token"
+        ),
+        th.Property(
+            "username",
+            th.StringType,
+            description="User/password username"
+        ),
+        th.Property(
+            "password",
+            th.StringType,
+            secret=True,
+            description="User/password username"
+        ),
+        th.Property(
+            "security_token",
+            th.StringType,
+            secret=True,
+            description="User/password generated security token. Reset under your Account Settings"
+        ),
+        th.Property(
+            "is_sandbox",
+            th.BooleanType,
+            default=False,
+            description="Is the Salesforce instance a sandbox"
+        ),
         th.Property(
             "action",
             th.StringType,
             default="update",
             allowed_values=SalesforceSink.valid_actions,
+            description="How to handle incomming records by default (insert/update/delete/hard_delete)"
         ),
     ).to_dict()
     default_sink_class = SalesforceSink


### PR DESCRIPTION
@dan-ladd I noticed you had settings descriptions in the readme but not in the tap itself so `--about` wasnt returning them. This just copies them into the tap itself.